### PR TITLE
Ignore warnings from the missing derived debug lint

### DIFF
--- a/src/lazy_static.rs
+++ b/src/lazy_static.rs
@@ -126,6 +126,7 @@ macro_rules! lazy_static {
         #[allow(missing_copy_implementations)]
         #[allow(non_camel_case_types)]
         #[allow(dead_code)]
+        #[allow(missing_debug_implementations)]
         $(#[$attr])*
         pub struct $N {__private_field: ()}
         #[doc(hidden)]
@@ -135,6 +136,7 @@ macro_rules! lazy_static {
         #[allow(missing_copy_implementations)]
         #[allow(non_camel_case_types)]
         #[allow(dead_code)]
+        #[allow(missing_debug_implementations)]
         $(#[$attr])*
         struct $N {__private_field: ()}
         #[doc(hidden)]


### PR DESCRIPTION
A Debug trait is probably not appropriate for the hidden static structs.

Discovered when using lazy static in another crate with `cargo rustc -- -Wmissing-debug-implementations`.

The other alternative to this change is to add a `#[derive(Debug)]` but that seems unreasonable.
