### PR TITLE
Fix build on nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,8 @@ extern crate std;
 
 // Re-export libcore using an alias so that the macros can work in no_std
 // crates while remaining compatible with normal crates.
-#[allow(private_in_public)]
 #[doc(hidden)]
-pub use core as __core;
+pub extern crate core as __core;
 
 /** This macro can be used to ensure that a function is called only once. It panics if the function
 is called a second time.


### PR DESCRIPTION
Hi.

https://github.com/rust-lang/rust/pull/42894 makes some compatibility lints in `rustc` deny-by-default and regression testing found that this crate is affected. Here's a patch fixing the deprecated code (see https://github.com/rust-lang/rust/issues/34537 for more information about the issue).
